### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-jsbeautifier
 amqp==2.5.2
 asgiref==3.2.4
 beautifulsoup4==4.8.2


### PR DESCRIPTION
Remove JSBeautifier as pip on Kali breaks that installation. Instead use aptitude to install as seen in the new README (sudo apt-get install python3-jsbeautifier)