### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ https://www.offensiveosint.io/leaklooker-gui-discover-browse-and-monitor-databas
 
 ~~~
 pip install -r requirements.txt
+sudo apt-get install python3-jsbeautifier
 ~~~ 
 
 # Install & Run
@@ -64,7 +65,7 @@ n a new window fire up redis
 
 In a new window (in main directory) run 
 
-```celery worker -A leaklooker --loglevel=info```
+```celery -A leaklooker worker --loglevel=info```
 
 For scheduling task (monitoring) run also 
 


### PR DESCRIPTION
Added aptitude install for JSBeautifier as pip on a fresh Kali install breaks it. Also, changed the celery command to the proper format for current celery version to run the worker.